### PR TITLE
More efficient spectrogram generation

### DIFF
--- a/AudioTagger/audioTagger.py
+++ b/AudioTagger/audioTagger.py
@@ -721,7 +721,7 @@ class AudioTagger(QtGui.QMainWindow):
         x_wins_ham = np.hamming(x_wins.shape[0])[..., np.newaxis] * x_wins
     
         # compute fft
-        fft_mat = np.fft.fft(x_wins_ham, n=nfft, axis=0)[:(nfft/2), :]
+        fft_mat = np.fft.rfft(x_wins_ham, n=nfft, axis=0)[:(nfft/2), :]
     
         # log magnitude
         fft_mat_lm = np.log(np.abs(fft_mat))


### PR DESCRIPTION
By using np.fft.rfft it will be 25-50% than np.fft.fft while still giving the exact same results. 

This is because it does not use the negative frequency terms that are sliced out anyway. 

See the following for more details:
http://docs.scipy.org/doc/numpy/reference/generated/numpy.fft.rfft.html