### PR TITLE
Initialize specWidth to a larger value

### DIFF
--- a/AudioTagger/audioTagger.py
+++ b/AudioTagger/audioTagger.py
@@ -83,7 +83,7 @@ class AudioTagger(QtGui.QMainWindow):
 
         self.activeLabel = None
         self.specHeight = 360
-        self.specWidth = 6000
+        self.specWidth = 20000
         self.contentChanged = False
         self.isDeletingRects = False
         self.yscale = 1


### PR DESCRIPTION
The current initial value seems to cause problems with long files. Making it a larger number is obviously a hack but it works for now.